### PR TITLE
Add support for 'export [a-z] class'

### DIFF
--- a/.ctags
+++ b/.ctags
@@ -1,6 +1,6 @@
 --langdef=typescript
 --langmap=typescript:.ts
---regex-typescript=/^[ \t]*(export[ \t]+(abstract[ \t]+)?)?class[ \t]+([a-zA-Z0-9_$]+)/\3/c,classes/
+--regex-typescript=/^[ \t]*(export[ \t]+([a-z]+[ \t]+)?)?class[ \t]+([a-zA-Z0-9_$]+)/\3/c,classes/
 --regex-typescript=/^[ \t]*(declare[ \t]+)?namespace[ \t]+([a-zA-Z0-9_$]+)/\2/c,modules/
 --regex-typescript=/^[ \t]*(export[ \t]+)?module[ \t]+([a-zA-Z0-9_$]+)/\2/n,modules/
 --regex-typescript=/^[ \t]*(export[ \t]+)?(async[ \t]+)?function[ \t]+([a-zA-Z0-9_$]+)/\3/f,functions/


### PR DESCRIPTION
Signed-off-by: NicolasNSSM <nnussbaum@gmail.com>

These ctags only support `export abstract class`. 
With a regex instead of `abstract` it now supports `default` too